### PR TITLE
switch to new agent image

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,12 @@ bridge network. Just follow the instructions below to get started.
 ### Hardware
 
 Minimum recommended for a production setup:
+
 * 2 Cores
 * 4 GiB RAM
 
 ### Software
+
 * Docker 18.06.0+, or an equivalent runtime with compose support
 
 ### RPC endpoints
@@ -29,8 +31,9 @@ service is able to handle this.
 
 ### Account
 
-We recomment creating a new account which will only be used for this specific
+We recommend creating a new account which will only be used for this specific
 instance of the agent. This account needs:
+
 * At least 0.5 L1 ETH
 * Eth on both rollups, at least 9 ETH per rollup, though we recommend 36 ETH
 * Tokens used to fulfill transfer requests: at least 50,000 USDC or DAI per rollup,
@@ -39,8 +42,8 @@ instance of the agent. This account needs:
 Additionally, make sure that your account is whitelisted for the mainnet deployment.
 If it is not, you can apply for whitelisting at hello@beamerbridge.com.
 
-
 ## Installation
+
 1. Provision a server that meets the hardware and software requirements listed
    above.
 
@@ -60,21 +63,20 @@ If it is not, you can apply for whitelisting at hello@beamerbridge.com.
          tar xz -C data --strip-components=1 beamer-1.0.3/deployments
     ```
 
-    The above command will download Beamer contracts' deployment information which the
-    agent needs in order to run.
+   The above command will download Beamer contracts' deployment information which the
+   agent needs in order to run.
 
 1. Copy your JSON keystore file to `data/account`.
-
 
 ### Mainnet configuration
 
 1. Edit `data/agent-mainnet.conf` and make sure that the following keys have correct values:
 
-   - `[account.path]` - the path to your JSON keystore file
-   - `[account.password]` - the password to unlock your keystore file
-   - `[chains.l1.rpc-url]` - the RPC endpoint to use for mainnet Ethereum (e.g. `https://mainnet.infura.io/v3/ID`)
-   - `[chains.arbitrum.rpc-url]` - the RPC endpoint to use for mainnet Arbitrum (e.g. `https://arb1.arbitrum.io/rpc`)
-   - `[chains.optimism.rpc-url]` - the RPC endpoint to use for mainnet Optimism (e.g. `https://mainnet.optimism.io`)
+    - `[account.path]` - the path to your JSON keystore file
+    - `[account.password]` - the password to unlock your keystore file
+    - `[chains.l1.rpc-url]` - the RPC endpoint to use for mainnet Ethereum (e.g. `https://mainnet.infura.io/v3/ID`)
+    - `[chains.arbitrum.rpc-url]` - the RPC endpoint to use for mainnet Arbitrum (e.g. `https://arb1.arbitrum.io/rpc`)
+    - `[chains.optimism.rpc-url]` - the RPC endpoint to use for mainnet Optimism (e.g. `https://mainnet.optimism.io`)
 
    When configuring RPC endpoints, please consider rate limits that may be in
    place since those may affect agent operation.
@@ -85,17 +87,16 @@ If it is not, you can apply for whitelisting at hello@beamerbridge.com.
    various configuration options, please refer to 
    [agent documentation](https://docs.beamerbridge.com/configuration.html).
 
-
 ### Testnet configuration
 
 1. Similarly to the mainnet configuration, edit `data/agent-goerli.conf` and make
    sure that the following keys have correct values:
 
-   - `[account.path]` - the path to your JSON keystore file
-   - `[account.password]` - the password to unlock your keystore file
-   - `[chains.l1.rpc-url]` - the RPC endpoint to use for Goerli Ethereum
-   - `[chains.arbitrum.rpc-url]` - the RPC endpoint to use for Goerli Arbitrum
-   - `[chains.optimism.rpc-url]` - the RPC endpoint to use for Goerli Optimism
+    - `[account.path]` - the path to your JSON keystore file
+    - `[account.password]` - the password to unlock your keystore file
+    - `[chains.l1.rpc-url]` - the RPC endpoint to use for Goerli Ethereum
+    - `[chains.arbitrum.rpc-url]` - the RPC endpoint to use for Goerli Arbitrum
+    - `[chains.optimism.rpc-url]` - the RPC endpoint to use for Goerli Optimism
 
    Other configuration settings are alredy prepared for testnet usage,
    including the test token configuration.
@@ -110,13 +111,13 @@ If it is not, you can apply for whitelisting at hello@beamerbridge.com.
 1. For mainnet, run:
 
    ```
-   docker compose -f docker-compose-mainnet.yml up -d
+   docker compose -f docker-compose-mainnet.yml up -d mainnet-agent
    ```
 
    For testnet, run:
 
    ```
-   docker compose -f docker-compose-goerli.yml up -d
+   docker compose -f docker-compose-goerli.yml up -d goerli-agent
    ```
 
    The services are configured to automatically restart in case of a crash or reboot.
@@ -140,5 +141,13 @@ You are now running an agent for the Beamer bridge. Thank you and please
 For more information on running an agent and updating to new agent versions,
 please refer to [documentation](https://docs.beamerbridge.com/running.html).
 
-We recommend that you provide your own monitoring. Setting up agent monitoring
-is out of scope of this document.
+## Beamer health-check
+
+The beamer executable includes a health-check command that can be used to
+analyze the beamer contracts and also reports agent liquidity. The health-check command
+fetches all the event executed by the contracts and analyzes them to determine
+whether there are missed fills, unclaimed requests or challenges. The script will
+send a notification to telegram or rocketchat depending on the configuration.
+
+To find out how to configure the health-check, please refer to the health-check 
+[documentation](https://docs.beamerbridge.com/configuration.html#notification-system).

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ If it is not, you can apply for whitelisting at hello@beamerbridge.com.
 
     ```shell
     cd run-your-own-agent
-    curl -sSfL https://github.com/beamer-bridge/beamer/archive/refs/tags/v1.0.3.tar.gz |
-         tar xz -C data --strip-components=1 beamer-1.0.3/deployments
+    curl -sSfL https://github.com/beamer-bridge/beamer/archive/refs/tags/v2.0.0.tar.gz |
+         tar xz -C data --strip-components=1 beamer-2.0.0/deployments
     ```
 
    The above command will download Beamer contracts' deployment information which the
@@ -74,7 +74,8 @@ If it is not, you can apply for whitelisting at hello@beamerbridge.com.
 
     - `[account.path]` - the path to your JSON keystore file
     - `[account.password]` - the password to unlock your keystore file
-    - `[chains.l1.rpc-url]` - the RPC endpoint to use for mainnet Ethereum (e.g. `https://mainnet.infura.io/v3/ID`)
+    - `[base-chain.rpc-url]` - the RPC endpoint to use for L1 resolution on mainnet Ethereum (e.g. `https://mainnet.infura.io/v3/ID`)
+    - `[chains.ethereum.rpc-url]` - the RPC endpoint to use for filling requests on mainnet Ethereum (e.g. `https://mainnet.infura.io/v3/ID`)
     - `[chains.arbitrum.rpc-url]` - the RPC endpoint to use for mainnet Arbitrum (e.g. `https://arb1.arbitrum.io/rpc`)
     - `[chains.optimism.rpc-url]` - the RPC endpoint to use for mainnet Optimism (e.g. `https://mainnet.optimism.io`)
 
@@ -94,7 +95,8 @@ If it is not, you can apply for whitelisting at hello@beamerbridge.com.
 
     - `[account.path]` - the path to your JSON keystore file
     - `[account.password]` - the password to unlock your keystore file
-    - `[chains.l1.rpc-url]` - the RPC endpoint to use for Goerli Ethereum
+    - `[base-chain.rpc-url]` - the RPC endpoint to use for L1 resolution on Goerli Ethereum
+    - `[chains.goerli.rpc-url]` - the RPC endpoint to use for filling requests on Goerli Ethereum
     - `[chains.arbitrum.rpc-url]` - the RPC endpoint to use for Goerli Arbitrum
     - `[chains.optimism.rpc-url]` - the RPC endpoint to use for Goerli Optimism
 
@@ -145,7 +147,7 @@ please refer to [documentation](https://docs.beamerbridge.com/running.html).
 
 The beamer executable includes a health-check command that can be used to
 analyze the beamer contracts and also reports agent liquidity. The health-check command
-fetches all the event executed by the contracts and analyzes them to determine
+fetches all the events emitted by the contracts and analyzes them to determine
 whether there are missed fills, unclaimed requests or challenges. The script will
 send a notification to telegram or rocketchat depending on the configuration.
 

--- a/data/agent-goerli.conf
+++ b/data/agent-goerli.conf
@@ -10,11 +10,16 @@ confirmation-blocks = 0
 path = "/data/account/keystore.json"
 password = ""
 
-[chains.base-chain]
+[base-chain]
 rpc-url = ""
+
+[chains.goerli]
+rpc-url = ""
+confirmation-blocks = 1
 
 [chains.optimism]
 rpc-url = ""
+poll-period = 5.0
 
 [chains.arbitrum]
 rpc-url = ""
@@ -36,11 +41,7 @@ confirmation-blocks = 2
 # - -1, the agent will approve type(uint256).max
 # If no value is given, the requested amount will be approved.
 TST = [
-    ["421613", "0x2644292EE5aed5c17BDcc6EDF1696ba802351cf6", "-1"],
-    ["420", "0xAcF5e964b76773166F69d6E53C1f7A9114a8E01D", "-1"]
-]
-
-USDC = [
-    ["421613", "0x1a65113Fb92916EF0D3043D651b469b653763F16", "-1"],
-    ["420", "0x6bCE0F297a204E1374860E0259EC31047a87B50F", "-1"]
+    ["5", "0x50fA2A18fd639E961c05B9ce722851C7ED346F93", -1],
+    ["421613", "0xf273c166586EDBe0Fad945d24080BAc5624d74d7", -1],
+    ["420", "0x56BdfB46fEA60884E82243C67D5556aD1beF9232", -1]
 ]

--- a/data/agent-mainnet.conf
+++ b/data/agent-mainnet.conf
@@ -2,30 +2,46 @@ log-level = "debug"
 deployment-dir = "/data/deployments/mainnet"
 fill-wait-time = 120
 unsafe-fill-time = 600
+poll-period = 5.0
+confirmation-blocks = 0
 
 [account]
 # make sure that the filename matches your keystore file
 path = "/data/account/keystore.json"
 password = ""
 
-[chains.l1]
+[base-chain]
 rpc-url = ""
+
+[chains.ethereum]
+rpc-url = ""
+confirmation-blocks = 1
 
 [chains.arbitrum]
 rpc-url = ""
 
 [chains.optimism]
 rpc-url = ""
+poll-period = 5.0
 
 [tokens]
 # Each token is represented by a pair [chain-id, token-address].
 # All tokens within the same list are considered equivalent and
 # transfers between them are allowed.
+# A third, optional value per token representation defines
+# the allowance amount, the agent will approve to the fill manager contract.
+# [chain-id, token-address, allowance]
+# Allowed values are:
+# - Any value > 0, which defines the exact allowance given
+# - -1, the agent will approve type(uint256).max
+# If no value is given, the requested amount will be approved.
 USDC = [
-    ["10", "0x7F5c764cBc14f9669B88837ca1490cCa17c31607"],
-    ["42161", "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8"]
+    ["1", "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", -1],
+    ["10", "0x7F5c764cBc14f9669B88837ca1490cCa17c31607", -1],
+    ["42161", "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8", -1]
 ]
 DAI = [
-    ["10", "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1"],
-    ["42161", "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1"]
+    ["1", "0x6B175474E89094C44Da98b954EedeAC495271d0F", -1],
+    ["10", "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1", -1],
+    ["42161", "0xDA10009cBd5D07dd0CeCc66161FC93D7c9000da1", -1]
 ]

--- a/data/beamer-health-check.conf
+++ b/data/beamer-health-check.conf
@@ -1,7 +1,6 @@
-[default]
 agent-address=""
-deployment-dir="../deployments/mainnet"
-cache-file-path="./"
+deployment-dir="/data/deployments/mainnet"
+cache-file-path="/data"
 notification-system="telegram"
 
 [notification.rocketchat]
@@ -16,12 +15,12 @@ request-throttling-in-sec=0
 
 [chains.arbitrum]
 rpc-url=""
-explorer=https://arbiscan.io/tx/
+explorer="https://arbiscan.io/tx/"
 chain-id=42161
 
 [chains.optimism]
 rpc-url=""
-explorer=https://optimistic.etherscan.io/tx/
+explorer="https://optimistic.etherscan.io/tx/"
 chain-id=10
 
 [tokens]

--- a/data/beamer-health-check.conf
+++ b/data/beamer-health-check.conf
@@ -1,0 +1,34 @@
+[default]
+agent-address=""
+deployment-dir="../deployments/mainnet"
+cache-file-path="./"
+notification-system="telegram"
+
+[notification.rocketchat]
+url=""
+channel=""
+request-throttling-in-sec=60
+
+[notification.telegram]
+token=""
+chat-id=""
+request-throttling-in-sec=0
+
+[chains.arbitrum]
+rpc-url=""
+explorer=https://arbiscan.io/tx/
+chain-id=42161
+
+[chains.optimism]
+rpc-url=""
+explorer=https://optimistic.etherscan.io/tx/
+chain-id=10
+
+[tokens]
+# Each token is represented by a pair [chain-id, token-address].
+# All tokens within the same list are considered equivalent and
+# transfers between them are allowed.
+USDC = [
+    ["10", "0x7F5c764cBc14f9669B88837ca1490cCa17c31607"],
+    ["42161", "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8"]
+]

--- a/data/beamer-health-check.conf
+++ b/data/beamer-health-check.conf
@@ -30,5 +30,5 @@ chain-id=10
 # transfers between them are allowed.
 USDC = [
     ["10", "0x7F5c764cBc14f9669B88837ca1490cCa17c31607"],
-    ["42161", "0xff970a61a04b1ca14834a43f5de4533ebddb5cc8"]
+    ["42161", "0xFF970A61A04b1cA14834A43f5dE4533eBDDB5CC8"]
 ]

--- a/docker-compose-goerli.yml
+++ b/docker-compose-goerli.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 
 x-defaults: &defaults
-  image: ghcr.io/beamer-bridge/beamer-agent:v1.0.3
+  image: ghcr.io/beamer-bridge/beamer:v2.0.0
   volumes:
     - ./data:/data
   logging:
@@ -15,4 +15,4 @@ services:
     << : *defaults
     restart: always
     # the agent command is included in the ENTRYPOINT declaration
-    command: --config /data/agent-goerli.conf --source-chain optimism --target-chain arbitrum
+    command: agent --config /data/agent-goerli.conf

--- a/docker-compose-mainnet.yml
+++ b/docker-compose-mainnet.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 
 x-defaults: &defaults
-  image: ghcr.io/beamer-bridge/beamer-agent:v1.0.3
+  image: ghcr.io/beamer-bridge/beamer:v1.0.2-31-gee4fef6
   volumes:
     - ./data:/data
   logging:
@@ -15,4 +15,24 @@ services:
     << : *defaults
     restart: always
     # the agent command is included in the ENTRYPOINT declaration
-    command: --config /data/agent-mainnet.conf --source-chain optimism --target-chain arbitrum
+    command: agent --config /data/agent-mainnet.conf --source-chain optimism --target-chain arbitrum
+
+  health-check:
+    << : *defaults
+    restart: always
+    stdin_open: true
+    entrypoint: /bin/sh
+    labels:
+      ofelia.enabled: "true"
+      ofelia.job-exec.heartbeat.schedule: "@every 6h"
+      ofelia.job-exec.heartbeat.no-overlap: "true"
+      ofelia.job-exec.heartbeat.command: "beamer health-check --config /data/beamer-health-check.conf"
+
+  ofelia:
+    image: mcuadros/ofelia:latest
+    restart: always
+    depends_on:
+      - health-check
+    command: daemon --docker
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:r

--- a/docker-compose-mainnet.yml
+++ b/docker-compose-mainnet.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 
 x-defaults: &defaults
-  image: ghcr.io/beamer-bridge/beamer:v1.0.2-31-gee4fef6
+  image: ghcr.io/beamer-bridge/beamer:v2.0.0
   volumes:
     - ./data:/data
   logging:
@@ -15,7 +15,7 @@ services:
     << : *defaults
     restart: always
     # the agent command is included in the ENTRYPOINT declaration
-    command: agent --config /data/agent-mainnet.conf --source-chain optimism --target-chain arbitrum
+    command: agent --config /data/agent-mainnet.conf
 
   health-check:
     << : *defaults


### PR DESCRIPTION
The new beamer executable is no longer called `beamer-agent`, but just `beamer`. It currently has 2 commands `agent` and `health-check`. The `agent` command behaves as the previous `beamer-agent` command.

The `health-check` command is used to analyze the beamer contracts and report problems such as - missed fills, missed claims or report on ongoing challenges. It also can report the agent’s balance.